### PR TITLE
fix: properly escape commit message in DESCRIPTION variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,8 @@ runs:
       if: ${{ inputs.registry == 'gcp' }}
     - name: Container Build
       shell: bash
+      env:
+        COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
       run: |
         if [ -z "${TAG_VERSION}" ]; then
           echo "TAG_VERSION must be set"
@@ -71,7 +73,7 @@ runs:
         fi
 
         if [ -z "${DESCRIPTION}" ]; then
-          DESCRIPTION=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          DESCRIPTION=$(echo "${COMMIT_MESSAGE}" | head -n 1)
         fi
 
         BUILD_ARGS="--build-arg TAG_VERSION=${TAG_VERSION} --build-arg BUILD_SHA=${GITHUB_SHA}"


### PR DESCRIPTION
## Summary

- Fix syntax error when commit messages contain special characters
- Use environment variable to properly escape commit message content
- Prevent bash syntax errors from parentheses, quotes, and multi-line content

## Problem

When a commit message contains special characters like `( )` or multi-line content, the GitHub Actions workflow fails with:

```
syntax error near unexpected token `('
```

This happens because the commit message is expanded directly into the bash script:

```bash
DESCRIPTION=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
```

## Solution

Pass the commit message through an environment variable first, which allows GitHub Actions to properly escape the content:

```bash
env:
  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
run: |
  DESCRIPTION=$(echo "${COMMIT_MESSAGE}" | head -n 1)
```

## Test Plan

- [x] Tested with commit message containing parentheses
- [x] Tested with multi-line commit messages
- [x] Verified no regression for simple commit messages

## Related Issues

Fixes the build failure in martoc/mcp-cloudcustodian-documentation#21728413490