### PR TITLE
feat: add reusable AWS ECR container build workflow

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,68 @@
+---
+name: AWS Container Build
+
+on:
+  workflow_call:
+    inputs:
+      region:
+        description: "AWS region for ECR (e.g., us-east-2, eu-west-1)"
+        required: true
+        type: string
+      repository_name:
+        description: "ECR repository name"
+        required: true
+        type: string
+      aws_account_id:
+        description: "AWS Account ID (12-digit)"
+        required: true
+        type: string
+      platforms:
+        description: "Platforms to build for"
+        required: false
+        type: string
+        default: "linux/arm64,linux/amd64"
+      build_args:
+        description: "Additional build arguments to pass to docker build"
+        required: false
+        type: string
+        default: ""
+      runner:
+        description: "GitHub Actions runner to use"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+    secrets:
+      aws_role_to_assume:
+        description: "ARN of the AWS IAM role to assume via OIDC"
+        required: true
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 50
+          fetch-tags: true
+      - name: Tag
+        uses: martoc/action-tag@v0
+        with:
+          skip-push: true
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.aws_role_to_assume }}
+          role-session-name: github-actions
+          aws-region: ${{ inputs.region }}
+      - name: Build & Push Container Image
+        uses: martoc/action-container-build@v0
+        with:
+          registry: aws
+          region: ${{ inputs.region }}
+          repository_name: ${{ inputs.repository_name }}
+          aws_account_id: ${{ inputs.aws_account_id }}
+          platforms: ${{ inputs.platforms }}
+          build_args: ${{ inputs.build_args }}

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ A GitHub Action that builds and pushes container images to Docker Hub, AWS ECR, 
 - Multi-platform builds using Docker buildx
 - Automatic OCI-compliant container labelling
 - Configurable build arguments and platforms
+- Reusable workflow for AWS ECR builds
 
 ## Quick Start
+
+### Docker Hub (Action)
 
 ```yaml
 - name: Build & Push Container Image
@@ -19,6 +22,20 @@ A GitHub Action that builds and pushes container images to Docker Hub, AWS ECR, 
   env:
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+```
+
+### AWS ECR (Reusable Workflow)
+
+```yaml
+jobs:
+  build:
+    uses: martoc/action-container-build/.github/workflows/aws.yml@v0
+    with:
+      region: us-east-2
+      repository_name: my-repo
+      aws_account_id: "123456789012"
+    secrets:
+      aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
 ```
 
 ## Documentation

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -215,6 +215,70 @@ jobs:
 * `gcp_project_id` input is required
 * GCP authentication must be configured (e.g., using `google-github-actions/auth`)
 
+## Reusable Workflows
+
+### AWS ECR (`aws.yml`)
+
+A reusable workflow that handles the full AWS ECR build pipeline, including
+credential configuration via OIDC, tagging, and building/pushing the container image.
+
+#### Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `region` | AWS region for ECR (e.g., `us-east-2`, `eu-west-1`) | Yes | - |
+| `repository_name` | ECR repository name | Yes | - |
+| `aws_account_id` | AWS Account ID (12-digit) | Yes | - |
+| `platforms` | Platforms to build for | No | `linux/arm64,linux/amd64` |
+| `build_args` | Additional build arguments | No | `""` |
+| `runner` | GitHub Actions runner to use | No | `ubuntu-24.04` |
+
+#### Secrets
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `aws_role_to_assume` | ARN of the AWS IAM role to assume via OIDC | Yes |
+
+#### Example
+
+```yaml
+name: Build Container
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    uses: martoc/action-container-build/.github/workflows/aws.yml@v0
+    with:
+      region: us-east-2
+      repository_name: my-repo
+      aws_account_id: "123456789012"
+    secrets:
+      aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+```
+
+#### Custom Platform Example
+
+```yaml
+jobs:
+  build:
+    uses: martoc/action-container-build/.github/workflows/aws.yml@v0
+    with:
+      region: eu-west-1
+      repository_name: my-repo
+      aws_account_id: "123456789012"
+      platforms: linux/arm64
+      build_args: --build-arg ENV=production
+    secrets:
+      aws_role_to_assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+```
+
 ## Container Labels
 
 The action automatically adds the following labels to the container image:


### PR DESCRIPTION
## Summary

- Add `aws.yml` reusable workflow that handles the full AWS ECR container build pipeline (OIDC credentials, tagging, build & push)
- Callers provide `region`, `repository_name`, `aws_account_id` as inputs and `aws_role_to_assume` as a secret
- Update README with AWS ECR quick start example
- Update USAGE.md with reusable workflow documentation, inputs, secrets, and examples

## Test plan

- [ ] Verify `make lint` passes with no errors
- [ ] Test the reusable workflow from a consumer repository by referencing this branch
- [ ] Validate OIDC credential flow with a configured AWS IAM role