### PR TITLE
feat: use dot separator for architecture in multi-arch image tags

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,8 @@ inputs:
   mode:
     description: >-
       Build mode: 'build' (default), 'multi-arch' (native single-arch build
-      with arch-suffixed tag), 'manifest' (create manifest list from
-      arch-suffixed images)
+      with dot-separated arch tag, e.g. 1.0.0.amd64), 'manifest' (create
+      manifest list from dot-separated arch images)
     required: false
     default: "build"
 runs:
@@ -199,8 +199,8 @@ runs:
               IMAGE_BASE="$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/${REPOSITORY_NAME}/${NAME}"
               if [ "${MODE}" = "multi-arch" ]; then
                 ARCH=$(echo "${PLATFORMS}" | cut -d'/' -f2)
-                TAGS="--tag ${IMAGE_BASE}:${TAG_VERSION}-${ARCH}"
-                PUSH_TAGS=(${IMAGE_BASE}:${TAG_VERSION}-${ARCH})
+                TAGS="--tag ${IMAGE_BASE}:${TAG_VERSION}.${ARCH}"
+                PUSH_TAGS=(${IMAGE_BASE}:${TAG_VERSION}.${ARCH})
               elif [ "${MODE}" = "manifest" ]; then
                 TAGS=""
                 PUSH_TAGS=()
@@ -224,8 +224,8 @@ runs:
           MANIFEST_AMENDS_LATEST=""
           for PLATFORM_ENTRY in "${ARCH_LIST[@]}"; do
             ARCH=$(echo "${PLATFORM_ENTRY}" | cut -d'/' -f2)
-            MANIFEST_AMENDS_VERSION="${MANIFEST_AMENDS_VERSION} ${IMAGE_BASE}:${TAG_VERSION}-${ARCH}"
-            MANIFEST_AMENDS_LATEST="${MANIFEST_AMENDS_LATEST} ${IMAGE_BASE}:${TAG_VERSION}-${ARCH}"
+            MANIFEST_AMENDS_VERSION="${MANIFEST_AMENDS_VERSION} ${IMAGE_BASE}:${TAG_VERSION}.${ARCH}"
+            MANIFEST_AMENDS_LATEST="${MANIFEST_AMENDS_LATEST} ${IMAGE_BASE}:${TAG_VERSION}.${ARCH}"
           done
           docker manifest create ${IMAGE_BASE}:${TAG_VERSION} ${MANIFEST_AMENDS_VERSION}
           docker manifest push ${IMAGE_BASE}:${TAG_VERSION}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -40,7 +40,7 @@ Before using this action, ensure that you have the following secrets configured 
 | `gcp_project_id` | Google Cloud Project ID | No | `""` |
 | `platforms` | Platforms to build for (e.g., `linux/amd64`, `linux/arm64`) | No | `linux/arm64,linux/amd64` |
 | `build_args` | Additional build arguments to pass to docker build | No | `""` |
-| `mode` | Build mode: `build` (default), `multi-arch` (native single-arch build with arch-suffixed tag), `manifest` (create manifest list from arch-suffixed images). `multi-arch` and `manifest` are AWS ECR only. | No | `"build"` |
+| `mode` | Build mode: `build` (default), `multi-arch` (native single-arch build with dot-separated arch tag, e.g. `1.0.0.amd64`), `manifest` (create manifest list from dot-separated arch images). `multi-arch` and `manifest` are AWS ECR only. | No | `"build"` |
 
 ### Environment Variables
 
@@ -302,6 +302,20 @@ jobs:
           platforms: linux/arm64,linux/amd64
           mode: manifest
 ```
+
+## Tag Format for Multi-Architecture Builds
+
+When using `multi-arch` mode, architecture-specific images are tagged using a dot (`.`) separator
+between the version and the architecture, e.g. `1.2.3.arm64` or `0.0.0-rc.e82285e.amd64`.
+
+This follows SemVer conventions as closely as Docker tag syntax allows. In SemVer, build metadata
+(such as architecture) should be appended with `+` (e.g. `1.0.0-rc.abc123+amd64`), but Docker
+image tags do not support the `+` character. Using `.` as the separator keeps the architecture
+clearly distinguished from pre-release identifiers (which use `-`) whilst remaining compatible
+with Docker and OCI registries.
+
+The `manifest` mode then combines these dot-separated arch tags into a single manifest list
+tagged with the base version (e.g. `1.2.3`) and `latest`.
 
 ## Registry-Specific Requirements
 


### PR DESCRIPTION
## Summary

- Replace `-` and `+` separators with `.` for architecture suffix in multi-arch image tags (e.g. `1.0.0.amd64` instead of `1.0.0-amd64`)
- Fix inconsistency between `multi-arch` and `manifest` modes — both now use the same `.` separator
- Update USAGE.md with a new section explaining the tag format convention and the SemVer rationale

## Rationale

In SemVer, architecture is build metadata and should use `+` (e.g. `1.0.0-rc.abc123+amd64`). However, Docker/OCI image tags do not support the `+` character. Using `-` conflates architecture with pre-release identifiers and affects version precedence ordering. Using `.` as the separator keeps architecture clearly distinguished from pre-release identifiers whilst remaining compatible with Docker and OCI registries.

## Test plan

- [ ] Verify `multi-arch` mode produces tags like `1.0.0.arm64`
- [ ] Verify `manifest` mode references the correct `.`-separated arch tags
- [ ] Verify `make lint` passes without new errors
