### PR TITLE
fix: upgrade aws-actions/configure-aws-credentials to v6 for Node 24

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -109,7 +109,7 @@ jobs:
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -226,7 +226,7 @@ jobs:
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -256,7 +256,7 @@ jobs:
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -287,7 +287,7 @@ jobs:
         with:
           skip-push: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions


### PR DESCRIPTION
## Summary

- Bump `aws-actions/configure-aws-credentials` from v4 to v6 in `docs/USAGE.md` so usage examples no longer reference an action running on Node.js 20.

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions are forced onto Node.js 24, and Node.js 20 is removed from the runner on 16 September 2026. `aws-actions/configure-aws-credentials@v6` runs on Node.js 24 by default.

## Test plan

- [ ] `make validate` passes
- [ ] CI checks pass
